### PR TITLE
Fixed capitalization of "GenePattern" in UI

### DIFF
--- a/js/lib/Galaxyuibuilder.js
+++ b/js/lib/Galaxyuibuilder.js
@@ -2051,7 +2051,7 @@ export class GalaxyUIBuilderView extends BaseWidgetView {
                                 <div class="galaxy-tool-list" style="display: none"> 
                                 </div>
                                  
-                                <div class="gpt" >  Send data to Genepattern  </div>
+                                <div class="gpt" >  Send data to GenePattern  </div>
                                 <div class="genepattern-tool-list" style="display: none"> 
                                 </div>
                             </div>


### PR DESCRIPTION
Changed one place where "GenePattern" appears in the UI to be consistent with its usual capitalization