### PR TITLE
Update version of nbtools in package.json

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -36,7 +36,7 @@
     "webpack-cli": "^4.5.0"
   },
   "dependencies": {
-    "@g2nb/nbtools": "22.3.0-beta.2",
+    "@g2nb/nbtools": "^23.7.0",
     "@jupyter-widgets/base": "^4.0.0",
     "@jupyterlab/notebook": "^3.0.4",
     "axios": "^0.21.1",


### PR DESCRIPTION
Updating the version of nbtools used by GiN brings forward a number of bug fixes that have been checked into nbtools since the last time package.json was updated.